### PR TITLE
Revert "Prevent clearfix from having dimensions in a flex layout"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 Record any changes that are made to the module
 
-## 4.1.8
-- Remove extra spacing from @clearfix on flex layouts
-
 ## 4.1.7
 - Update News keyline colour naming and value
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "gs-sass-tools",
-  "version": "4.1.8",
+  "version": "4.1.7",
   "homepage": "https://github.com/bbc/gs-sass-tools",
   "authors": [
     "Shaun Bent <shaun.bent@bbc.co.uk>"

--- a/tools/_clearfix.scss
+++ b/tools/_clearfix.scss
@@ -3,16 +3,10 @@
 //\*------------------------------------*/
 
 // Micro clearfix, as per: css-101.org/articles/clearfix/latest-new-clearfix-so-far.php
-//
-// 1. This prevents the clearfix from having dimensions in a flexbox layout.
-//    Older browsers which don't support the flex standard will ignore this
-//    and use `display: table` instead.
 @mixin clearfix() {
     &:after {
         content: "";
         display: table;
         clear: both;
-
-        display: inline-flex; /* [1] */
     }
 }


### PR DESCRIPTION
Reverts bbc/gs-sass-tools#19

This caused some funky issues when the clearfix was used between flex and non-flex layouts.

<img width="1283" alt="screen shot 2016-09-07 at 08 40 34" src="https://cloud.githubusercontent.com/assets/794263/18303861/156c1850-74d7-11e6-987a-c0e67a6259fd.png">
