### PR TITLE
Add Newsround colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 4.1.15 | Add colours needed by Newsround articles (e.g. teal === #50BAB3) |
 | 4.1.14 | Add colours needed by the News Navigation (e.g. trueblack === #000) |
 | 4.1.13 | Add new colour orange for UKChina Brand |
 | 4.1.12 | Add new colour silver for News |

--- a/_sass-tools.scss
+++ b/_sass-tools.scss
@@ -8,6 +8,7 @@
 @import 'settings/mybbc-colours';
 @import 'settings/sport-colours';
 @import 'settings/news-colours';
+@import 'settings/newsround-colours';
 
 // GEL tools
 @import '../gel-sass-tools/sass-tools';

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "gs-sass-tools",
-  "version": "4.1.14",
+  "version": "4.1.15",
   "homepage": "https://github.com/bbc/gs-sass-tools",
   "authors": [
     "Shaun Bent <shaun.bent@bbc.co.uk>"

--- a/settings/_newsround-colours.scss
+++ b/settings/_newsround-colours.scss
@@ -1,0 +1,10 @@
+///*------------------------------------*\
+//    # NEWSROUND COLOURS
+//\*------------------------------------*/
+
+// Core Colours
+$nwr-c-teal: #50BAB3;
+$nwr-c-blue: #2CB8C9;
+$nwr-c-purple: #413880;
+$nwr-c-pink: #C13783;
+$nwr-c-orange: #E87D43;


### PR DESCRIPTION
### What does this PR do?

Adds Newsround core colors to be used in [alephamp renderer](https://github.com/bbc/ws-alephamp-queue-renderer).

### Arises From

[PR (ws-alephamp-queue-renderer)](https://github.com/bbc/ws-alephamp-queue-renderer/pull/243)

### Jira Ticket
[WS2020-209](https://jira.dev.bbc.co.uk/browse/WS2020-209)

