### PR TITLE
Amend Newsround colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 4.1.16 | Update colors needed by Newsround articles (i.e. teal === #36D2C5) |
 | 4.1.15 | Add colours needed by Newsround articles (e.g. teal === #50BAB3) |
 | 4.1.14 | Add colours needed by the News Navigation (e.g. trueblack === #000) |
 | 4.1.13 | Add new colour orange for UKChina Brand |

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "gs-sass-tools",
-  "version": "4.1.15",
+  "version": "4.1.16",
   "homepage": "https://github.com/bbc/gs-sass-tools",
   "authors": [
     "Shaun Bent <shaun.bent@bbc.co.uk>"

--- a/settings/_newsround-colours.scss
+++ b/settings/_newsround-colours.scss
@@ -3,8 +3,7 @@
 //\*------------------------------------*/
 
 // Core Colours
-$nwr-c-teal: #50BAB3;
-$nwr-c-blue: #2CB8C9;
+$nwr-c-teal: #36D2C5;
 $nwr-c-purple: #413880;
 $nwr-c-pink: #C13783;
 $nwr-c-orange: #E87D43;


### PR DESCRIPTION
## [WS2020-209](https://jira.dev.bbc.co.uk/browse/WS2020-209)

This PR amends newsround colors.

### Arises From
[PR (ws-alephamp-queue-renderer)](https://github.com/bbc/ws-alephamp-queue-renderer/pull/263)