### PR TITLE
Update gel-grid dependency to latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 5.0.0 | Update gel-grid dependency to latest version | 
 | 4.1.16 | Update colors needed by Newsround articles (i.e. teal === #36D2C5) |
 | 4.1.15 | Add colours needed by Newsround articles (e.g. teal === #50BAB3) |
 | 4.1.14 | Add colours needed by the News Navigation (e.g. trueblack === #000) |

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "gs-sass-tools",
-  "version": "4.1.16",
+  "version": "5.0.0",
   "homepage": "https://github.com/bbc/gs-sass-tools",
   "authors": [
     "Shaun Bent <shaun.bent@bbc.co.uk>"
@@ -27,6 +27,6 @@
   "dependencies": {
     "gel-sass-tools": "^1.0.0",
     "gel-typography": "^2.0.0",
-    "gel-grid": "^1.0.0"
+    "gel-grid": "^3.0.0"
   }
 }


### PR DESCRIPTION
We are hoping to use this library alongside the latest version of gel-grid so have updated the version for this dependency. I have bumped this library's version up to 5 to ensure that it won't break for people currently using it, does this sound sensible? Let me know if this isn't something that we can do and we'll find another way round.

Thanks for your help 😄 
Anthony 