### PR TITLE
Update News colour value for 'stone dark'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 5.0.1 | Update News colour value for 'stone dark' | 
 | 5.0.0 | Update gel-grid dependency to latest version | 
 | 4.1.16 | Update colors needed by Newsround articles (i.e. teal === #36D2C5) |
 | 4.1.15 | Add colours needed by Newsround articles (e.g. teal === #50BAB3) |

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "gs-sass-tools",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "homepage": "https://github.com/bbc/gs-sass-tools",
   "authors": [
     "Shaun Bent <shaun.bent@bbc.co.uk>"

--- a/settings/_news-colours.scss
+++ b/settings/_news-colours.scss
@@ -41,7 +41,7 @@ $nw-c-ruby: #990000;
 $nw-c-silver: #BDBDBD;
 $nw-c-smoke: #EEEEEE;
 $nw-c-stone: #D5D0CD;
-$nw-c-stone-dark: #7B756F;
+$nw-c-stone-dark: #716C65;
 $nw-c-storm: #404040;
 $nw-c-white: #FFFFFF;
 $nw-c-ukchina: #E86C00;


### PR DESCRIPTION
Was #7B756F should be #716C65 (The new colour passes colour contrast levels)

https://jira.dev.bbc.co.uk/browse/NEWS-6062