### PR TITLE
Newsround 22 newsround colours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 5.0.5 | Add full palette of Newsround colours | 
 | 5.0.4 | Update Share tools colours and add reactions | 
 | 5.0.3 | Update Sport colours | 
 | 5.0.2 | Add News colour 'puddle' | 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ A number of products colour palettes are available as Sass variables:
 - [Sport](https://github.com/bbc/gs-sass-tools/blob/master/settings/_sport-colours.scss)
 - [News](https://github.com/bbc/gs-sass-tools/blob/master/settings/_news-colours.scss)
 - [MyBBC](https://github.com/bbc/gs-sass-tools/blob/master/settings/_mybbc-colours.scss)
+- [Newsround](https://github.com/bbc/gs-sass-tools/blob/master/settings/_newsround-colours.scss)
 
 ## Tools
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "gs-sass-tools",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "homepage": "https://github.com/bbc/gs-sass-tools",
   "authors": [
     "Shaun Bent <shaun.bent@bbc.co.uk>"

--- a/settings/_newsround-colours.scss
+++ b/settings/_newsround-colours.scss
@@ -3,7 +3,22 @@
 //\*------------------------------------*/
 
 // Core Colours
-$nwr-c-teal: #36D2C5;
-$nwr-c-purple: #413880;
-$nwr-c-pink: #C13783;
-$nwr-c-orange: #E87D43;
+$nwr-c-teal: #22D8D0;
+$nwr-c-purple: #561BAA;
+$nwr-c-pink: #D9298E;
+$nwr-c-orange: #FFB32C;
+$nwr-c-blue: #00C3E1;
+
+
+// Darks
+$nwr-c-charcoal-purple: #353866;
+$nwr-c-charcoal: #34314C;
+$nwr-c-black: #000000;
+
+// Pastels
+$nwr-c-white: #FFFFFF;
+$nwr-c-putty: #E6E6E6;
+$nwr-c-pastel-purple: #EFEAF7;
+$nwr-c-pastel-orange: #FFF3EA;
+$nwr-c-pastel-teal: #EAFBFA;
+$nwr-c-pastel-blue: #E6F9FC;


### PR DESCRIPTION
Extended the existing Newsround colours to a full palette of colours. These colours will then be available through Grandstand for the migration of the Newsround website from the World Service to Morph.

The only colour currently in use is Teal (36D2C5) on AMP pages. This will be updated to the new Teal (22D8D0).

<img width="972" alt="screen shot 2017-12-04 at 08 59 55" src="https://user-images.githubusercontent.com/16210451/33544220-dda429fc-d8d1-11e7-928a-677000a28d18.png">
