### PR TITLE
Update social brand colours for 2018

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| 5.0.8 | Update social brand colours (Facebook, Pintrest, Twitter, WhatsApp, YouTube) and add LinkedIn (colours brand compliant as of 5/4/18) | 
 | 5.0.7 | Added an additional colour to the Newsround colours | 
 | 5.0.6 | Added an additional colour to the Newsround colours | 
 | 5.0.5 | Add full palette of Newsround colours | 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "gs-sass-tools",
-  "version": "5.0.7",
+  "version": "5.0.8",
   "homepage": "https://github.com/bbc/gs-sass-tools",
   "authors": [
     "Shaun Bent <shaun.bent@bbc.co.uk>"

--- a/settings/_generic-colours.scss
+++ b/settings/_generic-colours.scss
@@ -7,14 +7,15 @@ $c-share-green: #0b8a0b;
 $c-share-green-active: #0da20d;
 
 // social networks
-$c-facebook: #3c5a98;
+$c-facebook: #3c5a99;
 $c-google-plus: #dc4b38;
 $c-instagram: #406e95;
-$c-pinterest: #cc2127;
+$c-pinterest: #bd081c;
 $c-soundcloud: #f50;
-$c-twitter: #47c7fa;
-$c-whatsapp: #1a870f;
-$c-youtube: #b31217;
+$c-twitter: #1da1f2;
+$c-whatsapp: #25d366;
+$c-youtube: #ff0000;
+$c-linkedin: #0077B5;
 
 // reactions
 $c-reactions-dislike: #e41838;


### PR DESCRIPTION
* Added LinkedIn
* Soundcloud, Google+, and Instagram unchanged due to lack of reliable
  brand guidelines